### PR TITLE
support for video urls without extension, add ext internally to make …

### DIFF
--- a/GSPlayer/Classes/Extension/AVAssetResourceLoadingRequest+Extensions.swift
+++ b/GSPlayer/Classes/Extension/AVAssetResourceLoadingRequest+Extensions.swift
@@ -18,7 +18,7 @@ extension AVAssetResourceLoadingRequest {
             urlString.hasPrefix(prefix)
             else { return nil }
         
-        return urlString.replacingOccurrences(of: prefix, with: "").url
+        return urlString.replacingOccurrences(of: prefix, with: "").url?.deletingPathExtension()
     }
     
 }

--- a/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
+++ b/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
@@ -43,7 +43,7 @@ extension AVPlayerItem {
             urlString.hasPrefix(AVPlayerItem.loaderPrefix)
             else { return nil }
         
-        return urlString.replacingOccurrences(of: AVPlayerItem.loaderPrefix, with: "").url
+        return urlString.replacingOccurrences(of: AVPlayerItem.loaderPrefix, with: "").url?.deletingPathExtension()
     }
     
     var isEnoughToPlay: Bool {
@@ -61,7 +61,7 @@ extension AVPlayerItem {
             return
         }
         
-        guard let loaderURL = (AVPlayerItem.loaderPrefix + url.absoluteString).url else {
+        guard let loaderURL = (AVPlayerItem.loaderPrefix + url.absoluteString + ".mp4").url else {
             VideoLoadManager.shared.reportError?(NSError(
                 domain: "me.gesen.player.loader",
                 code: -1,


### PR DESCRIPTION
…it work

As per https://github.com/wxxsw/GSPlayer/issues/77

This works with the sample videos in your Example app. I tried it also with a .mov URL.
More importantly, this adds support for URLs without an extension like the following:
https://media.staticontent.com/media/documents/132420b8-b6b0-4c29-8e81-3cec4522f6f1