### PR TITLE
fix #85 change loaderPrefix so that URL can be constructed on iOS 17

### DIFF
--- a/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
+++ b/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
@@ -35,7 +35,7 @@ public extension AVPlayerItem {
 
 extension AVPlayerItem {
     
-    static var loaderPrefix: String = "__loader__"
+    static var loaderPrefix: String = "loader-"
     
     var url: URL? {
         guard


### PR DESCRIPTION
To reproduce the issue: build the example app with Xcode 15 on an iOS 17 target simulator or device. Tap on Feed and let the video play for a few seconds. Return to home and turn off the internet connection. Tap on Feed again and the cached video won't start.
Works fine on iOS 16 target (also seems to work fine on iOS 17 if build with earlier Xcode version).

The problem is that the URL object cannot be constructed with a custom scheme like `__loader__https` anymore. Since the URL cannot be initialized with the custom scheme, the AVPlayerItem gets initialized with the original URL therefore the loader doesn't kick in and the player will try to load the video from the network.

Changing it to something without underscores like `loader-https` works.