### PR TITLE
Fix caching and ability to play urls with query params.

### DIFF
--- a/GSPlayer/Classes/Extension/AVAssetResourceLoadingRequest+Extensions.swift
+++ b/GSPlayer/Classes/Extension/AVAssetResourceLoadingRequest+Extensions.swift
@@ -11,7 +11,7 @@ import AVFoundation
 extension AVAssetResourceLoadingRequest {
     
     var url: URL? {
-        request.url?.removePrefix()
+        request.url?.deconstructed
     }
     
 }

--- a/GSPlayer/Classes/Extension/AVAssetResourceLoadingRequest+Extensions.swift
+++ b/GSPlayer/Classes/Extension/AVAssetResourceLoadingRequest+Extensions.swift
@@ -11,14 +11,7 @@ import AVFoundation
 extension AVAssetResourceLoadingRequest {
     
     var url: URL? {
-        let prefix = AVPlayerItem.loaderPrefix
-        
-        guard
-            let urlString = request.url?.absoluteString,
-            urlString.hasPrefix(prefix)
-            else { return nil }
-        
-        return urlString.replacingOccurrences(of: prefix, with: "").url?.deletingPathExtension()
+        request.url?.removePrefix()
     }
     
 }

--- a/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
+++ b/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
@@ -35,12 +35,10 @@ public extension AVPlayerItem {
 
 extension AVPlayerItem {
     
-    static var loaderPrefix: String = "loader-"
-    
     var isEnoughToPlay: Bool {
         guard
             let urlAsset = (asset as? AVURLAsset),
-            let url = urlAsset.url.removePrefix(),
+            let url = urlAsset.url.deconstructed,
             let configuration = try? VideoCacheManager.cachedConfiguration(for: url)
         else { return false }
         
@@ -53,7 +51,7 @@ extension AVPlayerItem {
             return
         }
         
-        guard let loaderURL = url.forceMP4()?.addPrefix() else {
+        guard let loaderURL = url.constructed else {
             VideoLoadManager.shared.reportError?(NSError(
                 domain: "me.gesen.player.loader",
                 code: -1,

--- a/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
+++ b/GSPlayer/Classes/Extension/AVPlayerItem+Extensions.swift
@@ -37,20 +37,12 @@ extension AVPlayerItem {
     
     static var loaderPrefix: String = "loader-"
     
-    var url: URL? {
-        guard
-            let urlString = (asset as? AVURLAsset)?.url.absoluteString,
-            urlString.hasPrefix(AVPlayerItem.loaderPrefix)
-            else { return nil }
-        
-        return urlString.replacingOccurrences(of: AVPlayerItem.loaderPrefix, with: "").url?.deletingPathExtension()
-    }
-    
     var isEnoughToPlay: Bool {
         guard
-            let url = url,
+            let urlAsset = (asset as? AVURLAsset),
+            let url = urlAsset.url.removePrefix(),
             let configuration = try? VideoCacheManager.cachedConfiguration(for: url)
-            else { return false }
+        else { return false }
         
         return configuration.downloadedByteCount >= 1024 * 768
     }
@@ -61,7 +53,7 @@ extension AVPlayerItem {
             return
         }
         
-        guard let loaderURL = (AVPlayerItem.loaderPrefix + url.absoluteString + ".mp4").url else {
+        guard let loaderURL = url.forceMP4()?.addPrefix() else {
             VideoLoadManager.shared.reportError?(NSError(
                 domain: "me.gesen.player.loader",
                 code: -1,

--- a/GSPlayer/Classes/Extension/URL+Extensions.swift
+++ b/GSPlayer/Classes/Extension/URL+Extensions.swift
@@ -1,0 +1,30 @@
+//
+//  URL+Extensions.swift
+//  GSPlayer
+//
+//  Created by Graeme Harrison on 2024/8/30.
+//  Copyright © 2024 Graeme Harrison. All rights reserved.
+//
+
+import AVFoundation
+
+extension URL {
+    private static let videoExtension = "mp4"
+    private static let prefix = AVPlayerItem.loaderPrefix
+    
+    func forceMP4() -> URL? {
+        guard pathExtension != Self.videoExtension else { return self }
+        
+        return deletingPathExtension().appendingPathExtension(Self.videoExtension)
+    }
+    
+    func addPrefix() -> URL? {
+        (Self.prefix + absoluteString).url
+    }
+    
+    func removePrefix() -> URL? {
+        guard absoluteString.hasPrefix(Self.prefix) else { return nil }
+        
+        return absoluteString.replacingOccurrences(of: Self.prefix, with: "").url
+    }
+}


### PR DESCRIPTION
### Fix ability to play URLs with query params:
- Because the "mp4" extension was always being added to the end of the loader url, it would break any urls with query parameters. Many image services use query params to perform transforms to media like scaling and blurring, etc. Using the `appendingPathExtension` function fixes the issue.
### Fix caching:
- I noticed that `isEnoughToPlay: Bool` would always return false from the `guard` statement. I believe it's because the `url` extension that was being used in logic such as `isEnoughToPlay: Bool` was deleting the path extension unnecessarily. Removing this seemed to fix the logic, and `isEnoughToPlay` now correctly returns `true` when the `downloadedByteCount` is sufficient.