### PR TITLE
Avoid Crash when AVAssetResourceLoadingRequest respond with data

### DIFF
--- a/GSPlayer/Classes/Loader/VideoLoader.swift
+++ b/GSPlayer/Classes/Loader/VideoLoader.swift
@@ -49,6 +49,7 @@ class VideoLoader {
     func remove(request: AVAssetResourceLoadingRequest) {
         if let index = requestLoaders.firstIndex(where: { $0.request == request }) {
             requestLoaders[index].finish()
+            guard requestLoaders.count >= index + 1 else { return }
             requestLoaders.remove(at: index)
         }
     }

--- a/GSPlayer/Classes/Loader/VideoRequestLoader.swift
+++ b/GSPlayer/Classes/Loader/VideoRequestLoader.swift
@@ -15,20 +15,23 @@ protocol VideoRequestLoaderDelegate: AnyObject {
 }
 
 class VideoRequestLoader {
-    
+
     weak var delegate: VideoRequestLoaderDelegate?
-    
+
     let request: AVAssetResourceLoadingRequest
-    
+
     private let downloader: VideoDownloader
-    
+    private var infoFilled = false
+    private let queue = DispatchQueue(label: "gsplayer.loader.\(UUID().uuidString)")
+    private var finished = false   // 标记避免 finish 后继续 respond
+
     init(request: AVAssetResourceLoadingRequest, downloader: VideoDownloader) {
         self.request = request
         self.downloader = downloader
         self.downloader.delegate = self
         self.fulfillContentInfomation()
     }
-    
+
     func start() {
         guard
             let dataRequest = request.dataRequest else {
@@ -48,21 +51,26 @@ class VideoRequestLoader {
             downloader.download(from: offset, length: length)
         }
     }
-    
+
     func cancel() {
+        finished = true
         downloader.cancel()
     }
-    
+
     func finish() {
-        if !request.isFinished {
-            request.finishLoading(with: NSError(
-                domain: "me.gesen.player.loader",
-                code: NSURLErrorCancelled,
-                userInfo: [NSLocalizedDescriptionKey: "Video load request is canceled"])
-            )
+        queue.async {
+            guard !self.finished else { return }
+            self.finished = true
+            if !self.request.isCancelled {
+                self.request.finishLoading(with: NSError(
+                    domain: "me.gesen.player.loader",
+                    code: NSURLErrorCancelled,
+                    userInfo: [NSLocalizedDescriptionKey: "Video load request is canceled"]
+                ))
+            }
         }
     }
-    
+
 }
 
 extension VideoRequestLoader: VideoDownloaderDelegate {
@@ -72,35 +80,78 @@ extension VideoRequestLoader: VideoDownloaderDelegate {
     }
     
     func downloader(_ downloader: VideoDownloader, didReceive data: Data) {
-        request.dataRequest?.respond(with: data)
-    }
-    
-    func downloader(_ downloader: VideoDownloader, didFinished error: Error?) {
-        guard (error as NSError?)?.code != NSURLErrorCancelled else { return }
-        
-        if error == nil {
-            request.finishLoading()
-        } else {
-            request.finishLoading(with: error)
+        guard !finished,
+              let req = request.dataRequest,
+              !request.isCancelled,
+              !data.isEmpty else { return }
+
+        // 严格按 requestedOffset / currentOffset / requestedLength 切片
+        queue.async { [weak self] in
+            guard let self = self,
+                  let req = self.request.dataRequest,
+                  !self.request.isCancelled,
+                  !self.finished else { return }
+
+            let requestedOffset = req.currentOffset == 0
+            ? req.requestedOffset
+            : req.currentOffset
+            let requestedLength = Int64(req.requestedLength)
+
+            // 这里假设 data 是从 fileOffset 开始的一段连续片段，若不是，请根据你 Downloader 的语义传入正确的 fileOffset
+            // 如果无法准确定位 data 对应的全局 offset，建议把 Downloader 按照 request 的 offset 精确拉取，避免“盲喂”
+            let fileOffset: Int64 = requestedOffset   // 关键：与上游保持一致
+            let start = Int(requestedOffset - fileOffset)
+            guard start >= 0, start < data.count else { return }
+
+            var remain = min(Int(requestedLength), data.count - start)
+            let chunkSize = 64 * 1024 // 64KB 小包，避免深层拷贝/重入
+
+            while remain > 0 && !self.request.isCancelled && !self.finished {
+                let len = min(chunkSize, remain)
+                let end = start + (Int(req.currentOffset - requestedOffset)) + len
+                let begin = end - len
+                guard begin >= 0, end <= data.count else { break }
+
+                let chunk = data.subdata(in: begin..<end)
+                if !chunk.isEmpty {
+                    req.respond(with: chunk)
+                }
+                remain -= len
+            }
         }
-        
-        delegate?.loader(self, didFinish: error)
     }
-    
+
+    func downloader(_ downloader: VideoDownloader, didFinished error: Error?) {
+        queue.async { [weak self] in
+            guard let self = self, !self.finished else { return }
+            self.finished = true
+
+            guard (error as NSError?)?.code != NSURLErrorCancelled else { return }
+
+            if let error {
+                self.request.finishLoading(with: error)
+            } else {
+                self.request.finishLoading()
+            }
+            self.delegate?.loader(self, didFinish: error)
+        }
+    }
+
 }
 
 private extension VideoRequestLoader {
-    
+
     func fulfillContentInfomation() {
-        guard
-            let info = downloader.info,
-            request.contentInformationRequest != nil else {
-            return
+        queue.async {
+            guard !self.infoFilled,
+                  let info = self.downloader.info,
+                  let cir = self.request.contentInformationRequest else { return }
+
+            cir.contentType = info.contentType
+            cir.contentLength = Int64(info.contentLength)
+            cir.isByteRangeAccessSupported = info.isByteRangeAccessSupported
+            self.infoFilled = true
         }
-        
-        request.contentInformationRequest?.contentType = info.contentType
-        request.contentInformationRequest?.contentLength = Int64(info.contentLength)
-        request.contentInformationRequest?.isByteRangeAccessSupported = info.isByteRangeAccessSupported
     }
-    
+
 }


### PR DESCRIPTION
相关 https://github.com/wxxsw/GSPlayer/issues/64

有一个稳定复现的设备(iOS 26 beta 6), 这台设备在更新前没有这个问题。场景是列表中有多个视频共用一个player.  ~~在按照AI的建议修改代码之后不再Crash, 因此提交一个Pull Request。 代码使用AI原版没有再做调整，可能需要作者进一步修改。~~(更新：频率降低了， 但是还是会出现，不能排除心理作用和复现的手法).  

更多信息：
场景是一个列表中有多个player。
我先实现了交流中的建议A&B仍然Crash， 然后把建议C&D也进行了实现，问题就解决了。
同时AI建议传参增加fileOffset: Int64， 对这方面不太了解/不确定修改后是否会影响正常功能， 因此不自己画蛇添足。

---

Show me the talk:  https://chatgpt.com/share/689d57d8-5934-8004-9181-98862d69293d