### PR TITLE
Fix invalid video cache content length

### DIFF
--- a/GSPlayer/Classes/Cache/VideoCacheConfiguration.swift
+++ b/GSPlayer/Classes/Cache/VideoCacheConfiguration.swift
@@ -21,6 +21,11 @@ public struct VideoCacheConfiguration: Codable {
         var configuration = try JSONDecoder().decode(VideoCacheConfiguration.self, from: data)
         configuration.filePath = filePath
         
+        if configuration.info?.contentLength ?? 0 <= 0 {
+            try? FileManager.default.removeItem(atPath: filePath)
+            return VideoCacheConfiguration(filePath: filePath)
+        }
+        
         return configuration
     }
     

--- a/GSPlayer/Classes/Download/VideoDownloader.swift
+++ b/GSPlayer/Classes/Download/VideoDownloader.swift
@@ -65,9 +65,7 @@ extension VideoDownloader: VideoDownloaderHandlerDelegate {
         
         if info == nil, let httpResponse = response as? HTTPURLResponse {
             
-            let contentLength = String(httpResponse
-                .value(forHeaderKey: "Content-Range")?
-                .split(separator: "/").last ?? "0").int ?? 0
+            let contentLength = httpResponse.contentLength
             
             let contentType = httpResponse
                 .value(forHeaderKey: "Content-Type") ?? ""
@@ -76,11 +74,13 @@ extension VideoDownloader: VideoDownloaderHandlerDelegate {
                 .value(forHeaderKey: "Accept-Ranges")?
                 .contains("bytes") ?? false
             
-            cacheHandler.set(info: VideoInfo(
-                contentLength: contentLength,
-                contentType: contentType,
-                isByteRangeAccessSupported: isByteRangeAccessSupported
-            ))
+            if contentLength > 0 {
+                cacheHandler.set(info: VideoInfo(
+                    contentLength: contentLength,
+                    contentType: contentType,
+                    isByteRangeAccessSupported: isByteRangeAccessSupported
+                ))
+            }
         }
         
         delegate?.downloader(self, didReceive: response)
@@ -97,6 +97,23 @@ extension VideoDownloader: VideoDownloaderHandlerDelegate {
 }
 
 private extension HTTPURLResponse {
+    
+    var contentLength: Int {
+        if let contentRangeLength = value(forHeaderKey: "Content-Range")?
+            .split(separator: "/")
+            .last
+            .flatMap({ String($0).int }),
+           contentRangeLength > 0 {
+            return contentRangeLength
+        }
+        
+        if let contentLength = value(forHeaderKey: "Content-Length")?.int,
+           contentLength > 0 {
+            return contentLength
+        }
+        
+        return expectedContentLength > 0 ? Int(expectedContentLength) : 0
+    }
     
     func value(forHeaderKey key: String) -> String? {
         return allHeaderFields


### PR DESCRIPTION
## 问题

某些可正常在 Safari 播放的 MP4，在 GSPlayer 中会触发 AVFoundation `-11829`，错误表现为“无法打开 / 此媒体可能已损坏”。

可能相关 https://github.com/wxxsw/GSPlayer/issues/111

排查发现问题不是视频文件本身损坏，而是 GSPlayer 缓存 metadata 异常。实际缓存文件已经完整写入，例如文件大小为 `5314622`，并且 cfg 中 fragments 也记录了完整区间：

```json
"fragments": [[0, 5314622]]
```

但同一份 cfg 的 info.contentLength 被写成了 0：

```json
"info": {
  "contentLength": 0,
  "contentType": "video/mp4",
  "isByteRangeAccessSupported": true
}
```

后续播放时，VideoRequestLoader 会把这个错误的 contentLength = 0 写入 AVAssetResourceLoadingRequest.contentInformationRequest.contentLength，导致 AVFoundation 认为资源元信息异常并报 -11829。

原因
旧逻辑在 GSPlayer/Classes/Download/VideoDownloader.swift 中只从 Content-Range 解析总长度。如果某次响应缺少 Content-Range，或 header 解析失败，就会 fallback 为 0 并持久化到 cfg。

修复
在 GSPlayer/Classes/Download/VideoDownloader.swift:68 改为通过 HTTPURLResponse.contentLength 统一解析长度。
解析顺序为 Content-Range -> Content-Length -> expectedContentLength。
只有 contentLength > 0 时才调用 cacheHandler.set(info:)，避免写入无效 cache info。
在 GSPlayer/Classes/Cache/VideoCacheConfiguration.swift:24 增加历史损坏 cfg 保护：如果读取到 contentLength <= 0，丢弃该 cfg 并重新生成空配置。

影响
这个修复可以避免损坏的缓存 metadata 被持久化，也可以让已经存在的损坏 cfg 在下次读取时自动失效，从而让播放器重新走正常加载流程。

## 验证
已有历史损坏cache视频, 在这个patch之后, 通过重新生成空配置之后播放成功
